### PR TITLE
Track the Number of Messages

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -71,7 +71,7 @@ type diskQueue struct {
 	// instantiation time metadata
 	name                string
 	dataPath            string
-	maxBytesDiskSize    int64
+	maxBytesDiskSpace   int64
 	maxBytesPerFile     int64 // cannot change once created
 	maxBytesPerFileRead int64
 	minMsgSize          int32
@@ -106,7 +106,7 @@ type diskQueue struct {
 	logf AppLogFunc
 
 	// disk limit implementation flag
-	enableDiskLimitation bool
+	diskLimitFeatIsOn bool
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata
@@ -115,43 +115,43 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
 
-	return NewWithDiskSize(name, dataPath,
+	return NewWithDiskSpace(name, dataPath,
 		0, maxBytesPerFile,
 		minMsgSize, maxMsgSize,
 		syncEvery, syncTimeout, logf)
 }
 
-// Another constructor that allows users to use Disk Size Limit feature
-// If user is not using Disk Size Limit feature, maxBytesDiskSize will
+// Another constructor that allows users to use Disk Space Limit feature
+// If user is not using Disk Space Limit feature, maxBytesDiskSpace will
 // be 0
-func NewWithDiskSize(name string, dataPath string,
-	maxBytesDiskSize int64, maxBytesPerFile int64,
+func NewWithDiskSpace(name string, dataPath string,
+	maxBytesDiskSpace int64, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
-	enableDiskLimitation := true
-	if maxBytesDiskSize <= 0 {
-		maxBytesDiskSize = 0
-		enableDiskLimitation = false
+	diskLimitFeatIsOn := true
+	if maxBytesDiskSpace <= 0 {
+		maxBytesDiskSpace = 0
+		diskLimitFeatIsOn = false
 	}
 	d := diskQueue{
-		name:                 name,
-		dataPath:             dataPath,
-		maxBytesDiskSize:     maxBytesDiskSize,
-		maxBytesPerFile:      maxBytesPerFile,
-		minMsgSize:           minMsgSize,
-		maxMsgSize:           maxMsgSize,
-		readChan:             make(chan []byte),
-		depthChan:            make(chan int64),
-		writeChan:            make(chan []byte),
-		writeResponseChan:    make(chan error),
-		emptyChan:            make(chan int),
-		emptyResponseChan:    make(chan error),
-		exitChan:             make(chan int),
-		exitSyncChan:         make(chan int),
-		syncEvery:            syncEvery,
-		syncTimeout:          syncTimeout,
-		logf:                 logf,
-		enableDiskLimitation: enableDiskLimitation,
+		name:              name,
+		dataPath:          dataPath,
+		maxBytesDiskSpace: maxBytesDiskSpace,
+		maxBytesPerFile:   maxBytesPerFile,
+		minMsgSize:        minMsgSize,
+		maxMsgSize:        maxMsgSize,
+		readChan:          make(chan []byte),
+		depthChan:         make(chan int64),
+		writeChan:         make(chan []byte),
+		writeResponseChan: make(chan error),
+		emptyChan:         make(chan int),
+		emptyResponseChan: make(chan error),
+		exitChan:          make(chan int),
+		exitSyncChan:      make(chan int),
+		syncEvery:         syncEvery,
+		syncTimeout:       syncTimeout,
+		logf:              logf,
+		diskLimitFeatIsOn: diskLimitFeatIsOn,
 	}
 
 	d.start()
@@ -335,7 +335,7 @@ func (d *diskQueue) readOne() ([]byte, error) {
 			stat, err := d.readFile.Stat()
 			if err == nil {
 				d.maxBytesPerFileRead = stat.Size()
-				if d.enableDiskLimitation {
+				if d.diskLimitFeatIsOn {
 					// last 8 bytes are reserved for the number of messages in this file
 					d.maxBytesPerFileRead -= 8
 				}
@@ -437,7 +437,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	totalBytes := int64(4 + dataLen)
 
 	// check if we reached the file size limit with this message
-	if d.enableDiskLimitation && d.writePos+totalBytes+8 >= d.maxBytesPerFile {
+	if d.diskLimitFeatIsOn && d.writePos+totalBytes+8 >= d.maxBytesPerFile {
 		// write number of messages in binary to file
 		err = binary.Write(&d.writeBuf, binary.BigEndian, d.writeMessages+1)
 		if err != nil {
@@ -458,7 +458,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 
 	fileSize := d.writePos
 
-	if d.enableDiskLimitation {
+	if d.diskLimitFeatIsOn {
 		// save space for the number of messages in this file
 		fileSize += 8
 		d.writeMessages += 1
@@ -520,8 +520,8 @@ func (d *diskQueue) retrieveMetaData() error {
 	}
 	defer f.Close()
 
-	// if user is using disk size limit feature
-	if d.enableDiskLimitation {
+	// if user is using disk space limit feature
+	if d.diskLimitFeatIsOn {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&d.depth,
 			&d.readFileNum, &d.readMessages, &d.readPos,
@@ -557,8 +557,8 @@ func (d *diskQueue) persistMetaData() error {
 		return err
 	}
 
-	// if user is using disk size limit feature
-	if d.enableDiskLimitation {
+	// if user is using disk space limit feature
+	if d.diskLimitFeatIsOn {
 		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			d.depth,
 			d.readFileNum, d.readMessages, d.readPos,

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -441,6 +441,8 @@ func (d *diskQueue) writeOne(data []byte) error {
 		if err != nil {
 			return err
 		}
+
+		totalBytes += 8
 	}
 
 	// only write to the file once

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -460,6 +460,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 		// save space for the number of messages in this file
 		fileSize += 8
 	}
+
 	if fileSize >= d.maxBytesPerFile {
 		if d.readFileNum == d.writeFileNum {
 			d.maxBytesPerFileRead = d.writePos

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -281,16 +281,15 @@ func (d *diskQueue) skipToNextRWFile() error {
 		}
 	}
 
-	d.depth = 0
-	d.nextReadPos = 0
-	d.readMessages = 0
-	d.readPos = 0
 	d.writeFileNum++
-	d.writeMessages = 0
 	d.writePos = 0
-
 	d.readFileNum = d.writeFileNum
+	d.readPos = 0
 	d.nextReadFileNum = d.writeFileNum
+	d.nextReadPos = 0
+	d.depth = 0
+	d.readMessages = 0
+	d.writeMessages = 0
 
 	return err
 }

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -119,6 +119,8 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 }
 
 // Another constructor that allows users to use Disk Space Limit feature
+// If user is not using Disk Space Limit feature, maxBytesDiskSpace will
+// be 0
 func NewWithDiskSpace(name string, dataPath string,
 	maxBytesDiskSpace int64, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
@@ -510,6 +512,7 @@ func (d *diskQueue) retrieveMetaData() error {
 	}
 	defer f.Close()
 
+	// if user is using disk space limit feature
 	if d.maxBytesDiskSpace > 0 {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&d.depth,
@@ -546,6 +549,7 @@ func (d *diskQueue) persistMetaData() error {
 		return err
 	}
 
+	// if user is using disk space limit feature
 	if d.maxBytesDiskSpace > 0 {
 		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			d.depth,

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -64,6 +64,7 @@ type diskQueue struct {
 	writeFileNum  int64
 	readMessages  int64
 	writeMessages int64
+	writeBytes    int64
 	depth         int64
 
 	sync.RWMutex
@@ -107,6 +108,9 @@ type diskQueue struct {
 
 	// disk limit implementation flag
 	diskLimitFeatIsOn bool
+
+	// the size of the
+	readMsgSize int32
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata
@@ -300,6 +304,7 @@ func (d *diskQueue) skipToNextRWFile() error {
 	d.depth = 0
 	d.readMessages = 0
 	d.writeMessages = 0
+	d.writeBytes = 0
 
 	return err
 }
@@ -308,7 +313,6 @@ func (d *diskQueue) skipToNextRWFile() error {
 // while advancing read positions and rolling files, if necessary
 func (d *diskQueue) readOne() ([]byte, error) {
 	var err error
-	var msgSize int32
 
 	if d.readFile == nil {
 		curFileName := d.fileName(d.readFileNum)
@@ -345,22 +349,22 @@ func (d *diskQueue) readOne() ([]byte, error) {
 		d.reader = bufio.NewReader(d.readFile)
 	}
 
-	err = binary.Read(d.reader, binary.BigEndian, &msgSize)
+	err = binary.Read(d.reader, binary.BigEndian, &d.readMsgSize)
 	if err != nil {
 		d.readFile.Close()
 		d.readFile = nil
 		return nil, err
 	}
 
-	if msgSize < d.minMsgSize || msgSize > d.maxMsgSize {
+	if d.readMsgSize < d.minMsgSize || d.readMsgSize > d.maxMsgSize {
 		// this file is corrupt and we have no reasonable guarantee on
 		// where a new message should begin
 		d.readFile.Close()
 		d.readFile = nil
-		return nil, fmt.Errorf("invalid message read size (%d)", msgSize)
+		return nil, fmt.Errorf("invalid message read size (%d)", d.readMsgSize)
 	}
 
-	readBuf := make([]byte, msgSize)
+	readBuf := make([]byte, d.readMsgSize)
 	_, err = io.ReadFull(d.reader, readBuf)
 	if err != nil {
 		d.readFile.Close()
@@ -368,7 +372,7 @@ func (d *diskQueue) readOne() ([]byte, error) {
 		return nil, err
 	}
 
-	totalBytes := int64(4 + msgSize)
+	totalBytes := int64(4 + d.readMsgSize)
 
 	// we only advance next* because we have not yet sent this to consumers
 	// (where readFileNum, readPos will actually be advanced)
@@ -459,6 +463,8 @@ func (d *diskQueue) writeOne(data []byte) error {
 	if d.diskLimitFeatIsOn {
 		// save space for the number of messages in this file
 		fileSize += 8
+		d.writeBytes += totalBytes
+		d.writeMessages += 1
 	}
 
 	if fileSize >= d.maxBytesPerFile {
@@ -468,7 +474,12 @@ func (d *diskQueue) writeOne(data []byte) error {
 
 		d.writeFileNum++
 		d.writePos = 0
-		d.writeMessages = 0
+
+		if d.diskLimitFeatIsOn {
+			// add bytes for the number of messages in the file
+			d.writeBytes += 8
+			d.writeMessages = 0
+		}
 
 		// sync every time we start writing to a new file
 		err = d.sync()
@@ -480,8 +491,6 @@ func (d *diskQueue) writeOne(data []byte) error {
 			d.writeFile.Close()
 			d.writeFile = nil
 		}
-	} else {
-		d.writeMessages += 1
 	}
 
 	return err
@@ -521,10 +530,10 @@ func (d *diskQueue) retrieveMetaData() error {
 
 	// if user is using disk space limit feature
 	if d.diskLimitFeatIsOn {
-		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d,%d\n",
 			&d.depth,
 			&d.readFileNum, &d.readMessages, &d.readPos,
-			&d.writeFileNum, &d.writeMessages, &d.writePos)
+			&d.writeBytes, &d.writeFileNum, &d.writeMessages, &d.writePos)
 	} else {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
 			&d.depth,
@@ -558,10 +567,10 @@ func (d *diskQueue) persistMetaData() error {
 
 	// if user is using disk space limit feature
 	if d.diskLimitFeatIsOn {
-		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d,%d\n",
 			d.depth,
 			d.readFileNum, d.readMessages, d.readPos,
-			d.writeFileNum, d.writeMessages, d.writePos)
+			d.writeBytes, d.writeFileNum, d.writeMessages, d.writePos)
 	} else {
 		_, err = fmt.Fprintf(f, "%d\n%d,%d\n%d,%d\n",
 			d.depth,
@@ -628,6 +637,8 @@ func (d *diskQueue) checkTailCorruption(depth int64) {
 }
 
 func (d *diskQueue) moveForward() {
+	// add bytes for the number of messages and the size of the message
+	readFileLen := int64(d.readMsgSize) + d.readPos + 12
 	oldReadFileNum := d.readFileNum
 	d.readFileNum = d.nextReadFileNum
 	d.readPos = d.nextReadPos
@@ -646,6 +657,8 @@ func (d *diskQueue) moveForward() {
 		if err != nil {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
 		}
+
+		d.writeBytes -= readFileLen
 	}
 
 	d.checkTailCorruption(d.depth)

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -71,7 +71,7 @@ type diskQueue struct {
 	// instantiation time metadata
 	name                string
 	dataPath            string
-	maxBytesDiskSpace   int64
+	maxBytesDiskSize    int64
 	maxBytesPerFile     int64 // cannot change once created
 	maxBytesPerFileRead int64
 	minMsgSize          int32
@@ -106,7 +106,7 @@ type diskQueue struct {
 	logf AppLogFunc
 
 	// disk limit implementation flag
-	diskLimitFeatIsOn bool
+	enableDiskLimitation bool
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata
@@ -115,43 +115,43 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
 
-	return NewWithDiskSpace(name, dataPath,
+	return NewWithDiskSize(name, dataPath,
 		0, maxBytesPerFile,
 		minMsgSize, maxMsgSize,
 		syncEvery, syncTimeout, logf)
 }
 
-// Another constructor that allows users to use Disk Space Limit feature
-// If user is not using Disk Space Limit feature, maxBytesDiskSpace will
+// Another constructor that allows users to use Disk Size Limit feature
+// If user is not using Disk Size Limit feature, maxBytesDiskSize will
 // be 0
-func NewWithDiskSpace(name string, dataPath string,
-	maxBytesDiskSpace int64, maxBytesPerFile int64,
+func NewWithDiskSize(name string, dataPath string,
+	maxBytesDiskSize int64, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
-	diskLimitFeatIsOn := true
-	if maxBytesDiskSpace <= 0 {
-		maxBytesDiskSpace = 0
-		diskLimitFeatIsOn = false
+	enableDiskLimitation := true
+	if maxBytesDiskSize <= 0 {
+		maxBytesDiskSize = 0
+		enableDiskLimitation = false
 	}
 	d := diskQueue{
-		name:              name,
-		dataPath:          dataPath,
-		maxBytesDiskSpace: maxBytesDiskSpace,
-		maxBytesPerFile:   maxBytesPerFile,
-		minMsgSize:        minMsgSize,
-		maxMsgSize:        maxMsgSize,
-		readChan:          make(chan []byte),
-		depthChan:         make(chan int64),
-		writeChan:         make(chan []byte),
-		writeResponseChan: make(chan error),
-		emptyChan:         make(chan int),
-		emptyResponseChan: make(chan error),
-		exitChan:          make(chan int),
-		exitSyncChan:      make(chan int),
-		syncEvery:         syncEvery,
-		syncTimeout:       syncTimeout,
-		logf:              logf,
-		diskLimitFeatIsOn: diskLimitFeatIsOn,
+		name:                 name,
+		dataPath:             dataPath,
+		maxBytesDiskSize:     maxBytesDiskSize,
+		maxBytesPerFile:      maxBytesPerFile,
+		minMsgSize:           minMsgSize,
+		maxMsgSize:           maxMsgSize,
+		readChan:             make(chan []byte),
+		depthChan:            make(chan int64),
+		writeChan:            make(chan []byte),
+		writeResponseChan:    make(chan error),
+		emptyChan:            make(chan int),
+		emptyResponseChan:    make(chan error),
+		exitChan:             make(chan int),
+		exitSyncChan:         make(chan int),
+		syncEvery:            syncEvery,
+		syncTimeout:          syncTimeout,
+		logf:                 logf,
+		enableDiskLimitation: enableDiskLimitation,
 	}
 
 	d.start()
@@ -335,7 +335,7 @@ func (d *diskQueue) readOne() ([]byte, error) {
 			stat, err := d.readFile.Stat()
 			if err == nil {
 				d.maxBytesPerFileRead = stat.Size()
-				if d.diskLimitFeatIsOn {
+				if d.enableDiskLimitation {
 					// last 8 bytes are reserved for the number of messages in this file
 					d.maxBytesPerFileRead -= 8
 				}
@@ -437,7 +437,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	totalBytes := int64(4 + dataLen)
 
 	// check if we reached the file size limit with this message
-	if d.diskLimitFeatIsOn && d.writePos+totalBytes+8 >= d.maxBytesPerFile {
+	if d.enableDiskLimitation && d.writePos+totalBytes+8 >= d.maxBytesPerFile {
 		// write number of messages in binary to file
 		err = binary.Write(&d.writeBuf, binary.BigEndian, d.writeMessages+1)
 		if err != nil {
@@ -458,7 +458,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 
 	fileSize := d.writePos
 
-	if d.diskLimitFeatIsOn {
+	if d.enableDiskLimitation {
 		// save space for the number of messages in this file
 		fileSize += 8
 		d.writeMessages += 1
@@ -520,8 +520,8 @@ func (d *diskQueue) retrieveMetaData() error {
 	}
 	defer f.Close()
 
-	// if user is using disk space limit feature
-	if d.diskLimitFeatIsOn {
+	// if user is using disk size limit feature
+	if d.enableDiskLimitation {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&d.depth,
 			&d.readFileNum, &d.readMessages, &d.readPos,
@@ -557,8 +557,8 @@ func (d *diskQueue) persistMetaData() error {
 		return err
 	}
 
-	// if user is using disk space limit feature
-	if d.diskLimitFeatIsOn {
+	// if user is using disk size limit feature
+	if d.enableDiskLimitation {
 		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			d.depth,
 			d.readFileNum, d.readMessages, d.readPos,

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -306,7 +306,7 @@ func (d *diskQueue) readOne() ([]byte, error) {
 		if d.readFileNum < d.writeFileNum {
 			stat, err := d.readFile.Stat()
 			if err == nil {
-				// last 4 bytes are reserved for the number of messages in this file
+				// last 8 bytes are reserved for the number of messages in this file
 				d.maxBytesPerFileRead = stat.Size() - 8
 			}
 		}

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -664,6 +664,7 @@ func (d *diskQueue) handleReadError() {
 		}
 		d.writeFileNum++
 		d.writePos = 0
+		d.writeMessages = 0
 	}
 
 	badFn := d.fileName(d.readFileNum)
@@ -684,6 +685,7 @@ func (d *diskQueue) handleReadError() {
 	d.readPos = 0
 	d.nextReadFileNum = d.readFileNum
 	d.nextReadPos = 0
+	d.readMessages = 0
 
 	// significant state change, schedule a sync on the next iteration
 	d.needSync = true

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -118,6 +118,7 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 		syncEvery, syncTimeout, logf)
 }
 
+// Another constructor that allows users to use Disk Space Limit feature
 func NewWithDiskSpace(name string, dataPath string,
 	maxBytesDiskSpace int64, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
@@ -149,6 +150,7 @@ func NewWithDiskSpace(name string, dataPath string,
 	return &d
 }
 
+// Get the last known state of DiskQueue from metadata and start ioLoop
 func (d *diskQueue) start() {
 	// no need to lock here, nothing else could possibly be touching this instance
 	err := d.retrieveMetaData()

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -437,7 +437,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	// check if we reached the file size limit with this message
 	if d.diskLimitFeatIsOn && d.writePos+totalBytes+8 >= d.maxBytesPerFile {
 		// write number of messages in binary to file
-		err = binary.Write(&d.writeBuf, binary.BigEndian, d.writeMessages)
+		err = binary.Write(&d.writeBuf, binary.BigEndian, d.writeMessages+1)
 		if err != nil {
 			return err
 		}
@@ -459,6 +459,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	if d.diskLimitFeatIsOn {
 		// save space for the number of messages in this file
 		fileSize += 8
+		d.writeMessages += 1
 	}
 
 	if fileSize >= d.maxBytesPerFile {
@@ -480,8 +481,6 @@ func (d *diskQueue) writeOne(data []byte) error {
 			d.writeFile.Close()
 			d.writeFile = nil
 		}
-	} else {
-		d.writeMessages += 1
 	}
 
 	return err

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -421,6 +421,8 @@ func (d *diskQueue) writeOne(data []byte) error {
 		return fmt.Errorf("invalid message write size (%d) minMsgSize=%d maxMsgSize=%d", dataLen, d.minMsgSize, d.maxMsgSize)
 	}
 
+	// add all data to writeBuf before writing to file
+	// this causes everything to be written to file or nothing
 	d.writeBuf.Reset()
 	err = binary.Write(&d.writeBuf, binary.BigEndian, dataLen)
 	if err != nil {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -441,8 +441,6 @@ func (d *diskQueue) writeOne(data []byte) error {
 		if err != nil {
 			return err
 		}
-
-		totalBytes += 8
 	}
 
 	// only write to the file once

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -328,6 +328,26 @@ next:
 			d.readMessages == 1 &&
 			d.writeMessages == 2 {
 			// success
+			goto final
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+final:
+	dq.Put(msg)
+
+	for i := 0; i < 10; i++ {
+		// test that write position and messages reset when a new file is created
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0)
+		if d.depth == 2 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 1 &&
+			d.readPos == 1004 &&
+			d.writePos == 0 &&
+			d.readMessages == 1 &&
+			d.writeMessages == 0 {
+			// success
 			goto done
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -259,7 +259,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, withDiskSpaceImpl bool) md {
+func readMetaDataFile(fileName string, retried int, withDiskSpaceFeat bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -267,14 +267,14 @@ func readMetaDataFile(fileName string, retried int, withDiskSpaceImpl bool) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, withDiskSpaceImpl)
+			return readMetaDataFile(fileName, retried, withDiskSpaceFeat)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	if withDiskSpaceImpl {
+	if withDiskSpaceFeat {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -259,7 +259,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, withDiskSpaceFeat bool) md {
+func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -267,14 +267,14 @@ func readMetaDataFile(fileName string, retried int, withDiskSpaceFeat bool) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, withDiskSpaceFeat)
+			return readMetaDataFile(fileName, retried, diskLimitFeatIsOn)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	if withDiskSpaceFeat {
+	if diskLimitFeatIsOn {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -292,7 +292,7 @@ func TestDiskQueueSyncAfterRead(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := New(dqName, tmpDir, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	dq := NewWithDiskSpace(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
 	defer dq.Close()
 
 	msg := make([]byte, 1000)

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -259,7 +259,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) md {
+func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -267,14 +267,14 @@ func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) m
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, enableDiskLimitation)
+			return readMetaDataFile(fileName, retried, diskLimitFeatIsOn)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	if enableDiskLimitation {
+	if diskLimitFeatIsOn {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,
@@ -348,7 +348,7 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewWithDiskSize(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	dq := NewWithDiskSpace(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
 	defer dq.Close()
 
 	msgSize := 1000

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -251,7 +251,6 @@ func TestDiskQueueCorruption(t *testing.T) {
 
 type md struct {
 	depth         int64
-	writeBytes    int64
 	readFileNum   int64
 	writeFileNum  int64
 	readMessages  int64
@@ -275,12 +274,11 @@ func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 	defer f.Close()
 
 	var ret md
-
 	if diskLimitFeatIsOn {
-		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d,%d\n",
+		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,
-			&ret.writeBytes, &ret.writeFileNum, &ret.writeMessages, &ret.writePos)
+			&ret.writeFileNum, &ret.writeMessages, &ret.writePos)
 	} else {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
 			&ret.depth,
@@ -360,7 +358,6 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 1 &&
-			d.writeBytes == 1004 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readPos == 0 &&
@@ -381,7 +378,6 @@ next:
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 1 &&
-			d.writeBytes == 2008 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readPos == 1004 &&
@@ -409,7 +405,6 @@ completeWriteFile:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 3 &&
-			d.writeBytes == 3020 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 1 &&
 			d.readPos == 1004 &&
@@ -434,9 +429,7 @@ completeReadFile:
 		// test that read position and messages reset when a file is completely read
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
-		t.Logf("Write bytes: %d", d.writeBytes)
 		if d.depth == 1 &&
-			d.writeBytes == 1004 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 1 &&
 			d.readPos == 0 &&

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -250,11 +250,13 @@ func TestDiskQueueCorruption(t *testing.T) {
 }
 
 type md struct {
-	depth        int64
-	readFileNum  int64
-	writeFileNum int64
-	readPos      int64
-	writePos     int64
+	depth         int64
+	readFileNum   int64
+	writeFileNum  int64
+	readMessages  int64
+	writeMessages int64
+	readPos       int64
+	writePos      int64
 }
 
 func readMetaDataFile(fileName string, retried int) md {
@@ -272,10 +274,10 @@ func readMetaDataFile(fileName string, retried int) md {
 	defer f.Close()
 
 	var ret md
-	_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
+	_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 		&ret.depth,
-		&ret.readFileNum, &ret.readPos,
-		&ret.writeFileNum, &ret.writePos)
+		&ret.readFileNum, &ret.readMessages, &ret.readPos,
+		&ret.writeFileNum, &ret.writeMessages, &ret.writePos)
 	if err != nil {
 		panic(err)
 	}
@@ -302,7 +304,9 @@ func TestDiskQueueSyncAfterRead(t *testing.T) {
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readPos == 0 &&
-			d.writePos == 1004 {
+			d.writePos == 1004 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 1 {
 			// success
 			goto next
 		}
@@ -320,7 +324,9 @@ next:
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readPos == 1004 &&
-			d.writePos == 2008 {
+			d.writePos == 2008 &&
+			d.readMessages == 1 &&
+			d.writeMessages == 2 {
 			// success
 			goto done
 		}

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -259,7 +259,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
+func readMetaDataFile(fileName string, retried int, withDiskSpaceFeat bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -267,14 +267,14 @@ func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, diskLimitFeatIsOn)
+			return readMetaDataFile(fileName, retried, withDiskSpaceFeat)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	if diskLimitFeatIsOn {
+	if withDiskSpaceFeat {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -259,7 +259,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
+func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -267,14 +267,14 @@ func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, diskLimitFeatIsOn)
+			return readMetaDataFile(fileName, retried, enableDiskLimitation)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	if diskLimitFeatIsOn {
+	if enableDiskLimitation {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,
@@ -348,7 +348,7 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewWithDiskSpace(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	dq := NewWithDiskSize(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
 	defer dq.Close()
 
 	msgSize := 1000


### PR DESCRIPTION
# Implementation
- Create new constructor for DiskQueue that uses the new Disk Size Limit feature.
- Implement the handling of Depth for the Disk Size Limit feature.
- If using the Disk Size Limit feature:
  - Track the number of messages in the write file and write it to the end of the file
  - Track the number of messages in the read file that have been read
  - Write the writeMessages and readMessages to the MetaData

# Testing
- test that write and read messages increment normally after putting and/or getting data
- test that write position and messages reset when a new file is created
- test that read position and messages reset when a file is completely read

# Next Steps
- Calculate the total disk space used by tracking writeBytes (the number of bytes written that have not been deleted) and readBytes (the number of bytes to be deleted)

## Note
This pr will only handle the tracking of writeMessages and readMessages. The implementation of making space when we surpass the diskSizeLimit will come later.
