### PR TITLE
Track disk size

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -645,7 +645,7 @@ func (d *diskQueue) checkTailCorruption(depth int64) {
 
 func (d *diskQueue) moveForward() {
 	// add bytes for the number of messages and the size of the message
-	readFileSize := int64(d.readMsgSize) + d.readPos + 12
+	readFileSize := int64(d.readMsgSize) + d.readPos + numFileMsgsBytes + 4
 
 	oldReadFileNum := d.readFileNum
 	d.readFileNum = d.nextReadFileNum

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -719,7 +719,7 @@ func (d *diskQueue) handleReadError() {
 				badFileSize = stat.Size()
 			} else {
 				// max file size
-				badFileSize = int64(d.maxMsgSize) + d.maxBytesPerFile + 4
+				badFileSize = int64(d.maxMsgSize) + d.maxBytesPerFile + 4 + numFileMsgsBytes
 			}
 		}
 

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -686,6 +686,11 @@ func (d *diskQueue) handleReadError() {
 		}
 		d.writeFileNum++
 		d.writePos = 0
+
+		if d.diskLimitFeatIsOn {
+			d.writeMessages = 0
+			d.writeBytes = 0
+		}
 	}
 
 	badFn := d.fileName(d.readFileNum)
@@ -706,6 +711,9 @@ func (d *diskQueue) handleReadError() {
 	d.readPos = 0
 	d.nextReadFileNum = d.readFileNum
 	d.nextReadPos = 0
+	if d.diskLimitFeatIsOn {
+		d.readMessages = 0
+	}
 
 	// significant state change, schedule a sync on the next iteration
 	d.needSync = true

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -87,6 +87,10 @@ type diskQueue struct {
 	nextReadPos     int64
 	nextReadFileNum int64
 
+	// keep track of the msg size we have read
+	// (but not yet sent over readChan)
+	readMsgSize int32
+
 	readFile  *os.File
 	writeFile *os.File
 	reader    *bufio.Reader
@@ -108,9 +112,6 @@ type diskQueue struct {
 
 	// disk limit implementation flag
 	diskLimitFeatIsOn bool
-
-	// the size of the
-	readMsgSize int32
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -649,11 +649,13 @@ func (d *diskQueue) moveForward() {
 	d.readFileNum = d.nextReadFileNum
 	d.readPos = d.nextReadPos
 	d.depth -= 1
-	d.readMessages += 1
+
+	if d.diskLimitFeatIsOn {
+		d.readMessages += 1
+	}
 
 	// see if we need to clean up the old file
 	if oldReadFileNum != d.nextReadFileNum {
-		d.readMessages = 0
 
 		// sync every time we start reading from a new file
 		d.needSync = true
@@ -664,7 +666,10 @@ func (d *diskQueue) moveForward() {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
 		}
 
-		d.writeBytes -= readFileLen
+		if d.diskLimitFeatIsOn {
+			d.readMessages = 0
+			d.writeBytes -= readFileLen
+		}
 	}
 
 	d.checkTailCorruption(d.depth)

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -302,9 +302,12 @@ func (d *diskQueue) skipToNextRWFile() error {
 	d.nextReadFileNum = d.writeFileNum
 	d.nextReadPos = 0
 	d.depth = 0
-	d.readMessages = 0
-	d.writeMessages = 0
-	d.writeBytes = 0
+
+	if d.diskLimitFeatIsOn {
+		d.writeBytes = 0
+		d.readMessages = 0
+		d.writeMessages = 0
+	}
 
 	return err
 }

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -359,6 +359,7 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 1 &&
+			d.writeBytes == 1004 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readMessages == 0 &&
@@ -379,6 +380,7 @@ next:
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 1 &&
+			d.writeBytes == 2008 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readMessages == 1 &&
@@ -432,6 +434,7 @@ completeReadFile:
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 1 &&
+			d.writeBytes == 1004 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 1 &&
 			d.readMessages == 0 &&

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -363,10 +363,10 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 			d.writeBytes == 1004 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
-			d.readPos == 0 &&
-			d.writePos == 1004 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 1 {
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 {
 			// success
 			goto next
 		}
@@ -384,10 +384,10 @@ next:
 			d.writeBytes == 2008 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
-			d.readPos == 1004 &&
-			d.writePos == 2008 &&
 			d.readMessages == 1 &&
-			d.writeMessages == 2 {
+			d.writeMessages == 2 &&
+			d.readPos == 1004 &&
+			d.writePos == 2008 {
 			// success
 			goto completeWriteFile
 		}
@@ -409,13 +409,13 @@ completeWriteFile:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 3 &&
-			d.writeBytes == 3020 &&
+			d.writeBytes == 2048 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 1 &&
-			d.readPos == 1004 &&
-			d.writePos == 0 &&
 			d.readMessages == 1 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 1004 &&
+			d.writePos == 0 {
 			// success
 			goto completeReadFile
 		}
@@ -439,10 +439,10 @@ completeReadFile:
 			d.writeBytes == 1004 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 1 &&
-			d.readPos == 0 &&
-			d.writePos == 1004 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 1 {
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 {
 			// success
 			goto completeWriteFileAgain
 		}
@@ -467,12 +467,13 @@ completeWriteFileAgain:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 7 &&
+			d.writeBytes == 5068 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 3 &&
-			d.readPos == 0 &&
-			d.writePos == 0 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 {
 			// success
 			goto completeReadFileAgain
 		}
@@ -495,12 +496,13 @@ completeReadFileAgain:
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 0 &&
+			d.writeBytes == 0 &&
 			d.readFileNum == 3 &&
 			d.writeFileNum == 3 &&
-			d.readPos == 0 &&
-			d.writePos == 0 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 {
 			// success
 			goto done
 		}

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -251,6 +251,7 @@ func TestDiskQueueCorruption(t *testing.T) {
 
 type md struct {
 	depth         int64
+	writeBytes    int64
 	readFileNum   int64
 	writeFileNum  int64
 	readMessages  int64
@@ -275,10 +276,10 @@ func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) m
 
 	var ret md
 	if enableDiskLimitation {
-		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,
-			&ret.writeFileNum, &ret.writeMessages, &ret.writePos)
+			&ret.writeBytes, &ret.writeFileNum, &ret.writeMessages, &ret.writePos)
 	} else {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
 			&ret.depth,


### PR DESCRIPTION
# Implementation
- If using the disk size limit feature
  - Track the number of bytes written that do not have the .bad file extension with writeBytes
  - Write writeBytes to MetaData

# Testing 
- test that writeBytes increment after putting data
- test that writeBytes decrements when a file is completely read

# Next PR
- implement disk size limit feature that will delete the oldest file first in order to make space
