### PR TITLE
Disk size limit

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -941,7 +941,6 @@ func (d *diskQueue) handleReadError() {
 		d.writePos = 0
 
 		if d.enableDiskLimitation {
-			d.totalDiskSpaceUsed = 0
 			d.writeMessages = 0
 		}
 	}

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -888,7 +888,7 @@ func (d *diskQueue) moveToNextReadFile(readFileSize int64) {
 
 func (d *diskQueue) moveForward() {
 	// add bytes for the number of messages and the size of the message
-	readFileSize := int64(d.readMsgSize) + d.readPos + 12
+	readFileSize := int64(d.readMsgSize) + d.readPos + numFileMsgBytes + 4
 	d.depth -= 1
 
 	if d.enableDiskLimitation {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -562,6 +562,7 @@ func (d *diskQueue) freeUpDiskSpace() error {
 				d.badBytes -= oldestBadFileInfo.Size()
 			} else {
 				d.logf(ERROR, "DISKQUEUE(%s) failed to remove .bad file(%s) - %s", d.name, oldestBadFileInfo.Name(), err)
+				return err
 			}
 		} else {
 			// we overestimated the size of some .bad files and removed too much from writeBytes

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -526,6 +526,7 @@ func (d *diskQueue) freeUpDiskSpace() error {
 			err = os.Remove(badFileFilePath)
 			if err == nil {
 				d.writeBytes -= oldestBadFileInfo.Size()
+				d.badBytes -= oldestBadFileInfo.Size()
 			} else {
 				d.logf(ERROR, "DISKQUEUE(%s) failed to remove .bad file(%s) - %s", d.name, oldestBadFileInfo.Name(), err)
 			}
@@ -588,7 +589,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 		metaDataFileSize := d.metaDataFileSize()
 
 		// check if we will reach or surpass file size limit
-		if d.badBytes+d.writePos+totalBytes+numFileMsgBytes >= d.maxBytesPerFile {
+		if d.writePos+totalBytes+numFileMsgBytes >= d.maxBytesPerFile {
 			reachedFileSizeLimit = true
 		}
 
@@ -598,7 +599,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 		}
 
 		// keep freeing up disk space until we have enough space to write this message
-		for metaDataFileSize+d.writeBytes+expectedBytesIncrease > d.maxBytesDiskSpace {
+		for d.badBytes+metaDataFileSize+d.writeBytes+expectedBytesIncrease > d.maxBytesDiskSpace {
 			d.freeUpDiskSpace()
 		}
 	} else if d.writePos+totalBytes >= d.maxBytesPerFile {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -923,6 +923,9 @@ func (d *diskQueue) handleReadError() {
 		var badFileSize int64
 		if d.readFileNum == d.writeFileNum {
 			badFileSize = d.writeBytes
+
+			// we moved on to the next writeFile
+			d.writeMessages = 0
 		} else {
 			var stat os.FileInfo
 			stat, err = os.Stat(badRenameFn)
@@ -936,6 +939,8 @@ func (d *diskQueue) handleReadError() {
 
 		d.badBytes += badFileSize
 		d.writeBytes -= badFileSize
+
+		d.readMessages = 0
 	}
 
 	d.readFileNum++

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -399,11 +399,11 @@ func (d *diskQueue) readOne() ([]byte, error) {
 	return readBuf, nil
 }
 
+// get the size of the metaData file or its max possible size
 func (d *diskQueue) metaDataFileSize() int64 {
 	var err error
 	var metaDataFile *os.File
 
-	// get the MetaData file size
 	metaDataFile, err = os.OpenFile(d.metaDataFileName(), os.O_RDONLY, 0600)
 
 	var metaDataFileSize int64

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -890,7 +890,6 @@ func (d *diskQueue) moveToNextReadFile() {
 
 		if d.enableDiskLimitation {
 			d.readMessages = 0
-			// err = d.updateTotalDiskSpaceUsed()
 			if err != nil {
 				d.logf(ERROR, "DISKQUEUE(%s) failed to update write bytes - %s", d.name, err)
 			}
@@ -943,7 +942,6 @@ func (d *diskQueue) handleReadError() {
 			d.totalDiskSpaceUsed = 0
 			d.writeMessages = 0
 		} else {
-			// err = d.updateTotalDiskSpaceUsed()
 			if err != nil {
 				d.logf(ERROR, "DISKQUEUE(%s) failed to update write bytes - %s", d.name, err)
 			}

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -515,7 +515,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	}
 
 	// check if we have enough space to write this message
-	if d.diskLimitFeatIsOn && d.writeBytes+d.metaDataFileSize()+int64(4+dataLen)+numFileMsgBytes > d.maxBytesDiskSpace {
+	for d.diskLimitFeatIsOn && d.writeBytes+d.metaDataFileSize()+int64(4+dataLen)+numFileMsgBytes > d.maxBytesDiskSpace {
 		err = d.freeUpDiskSpace()
 		if err != nil {
 			d.logf(ERROR, "Not able to free up space: %s", err)

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -87,6 +87,10 @@ type diskQueue struct {
 	nextReadPos     int64
 	nextReadFileNum int64
 
+	// keep track of the msg size we have read
+	// (but not yet sent over readChan)
+	readMsgSize int32
+
 	readFile  *os.File
 	writeFile *os.File
 	reader    *bufio.Reader
@@ -108,9 +112,6 @@ type diskQueue struct {
 
 	// disk limit implementation flag
 	diskLimitFeatIsOn bool
-
-	// the size of the
-	readMsgSize int32
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -855,13 +855,12 @@ func (d *diskQueue) moveToNextReadFile() {
 
 		fn := d.fileName(oldReadFileNum)
 		oldFileInfo, _ := os.Stat(fn)
-		oldFileSize := oldFileInfo.Size()
 
 		err := os.Remove(fn)
 		if err != nil {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
 		} else {
-			d.logf(INFO, "DISKQUEUE(%s) removed(%s) of size(%d bytes)", d.name, fn, oldFileSize)
+			d.logf(INFO, "DISKQUEUE(%s) removed(%s) of size(%d bytes)", d.name, fn, oldFileInfo.Size())
 		}
 
 		if d.enableDiskLimitation {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -601,14 +601,6 @@ func (d *diskQueue) writeOne(data []byte) error {
 	reachedFileSizeLimit := false
 
 	if d.diskLimitFeatIsOn {
-		// If there the data to be written is bigger than the disk size limit, do not write
-		if totalBytes+8 > d.maxBytesDiskSpace {
-			return errors.New("Not enough disk space to write message")
-		}
-
-		// check if we have enough space to write this message
-		metaDataFileSize := d.metaDataFileSize()
-
 		// check if we will reach or surpass file size limit
 		if d.writePos+totalBytes+numFileMsgBytes >= d.maxBytesPerFile {
 			reachedFileSizeLimit = true
@@ -618,6 +610,14 @@ func (d *diskQueue) writeOne(data []byte) error {
 		if reachedFileSizeLimit {
 			expectedBytesIncrease += numFileMsgBytes
 		}
+
+		// If the data to be written is bigger than the disk size limit, do not write
+		if expectedBytesIncrease > d.maxBytesDiskSpace {
+			return errors.New("message size surpasses disk size limit")
+		}
+
+		// check if we have enough space to write this message
+		metaDataFileSize := d.metaDataFileSize()
 
 		// keep freeing up disk space until we have enough space to write this message
 		for d.badBytes+metaDataFileSize+d.writeBytes+expectedBytesIncrease > d.maxBytesDiskSpace {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -79,7 +79,7 @@ type diskQueue struct {
 	// instantiation time metadata
 	name                string
 	dataPath            string
-	maxBytesDiskSize    int64
+	maxBytesDiskSpace   int64
 	maxBytesPerFile     int64 // cannot change once created
 	maxBytesPerFileRead int64
 	minMsgSize          int32
@@ -93,10 +93,6 @@ type diskQueue struct {
 	// (but not yet sent over readChan)
 	nextReadPos     int64
 	nextReadFileNum int64
-
-	// keep track of the msg size we have read
-	// (but not yet sent over readChan)
-	readMsgSize int32
 
 	readFile  *os.File
 	writeFile *os.File
@@ -127,17 +123,17 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
 
-	return NewWithDiskSize(name, dataPath,
+	return NewWithDiskSpace(name, dataPath,
 		0, maxBytesPerFile,
 		minMsgSize, maxMsgSize,
 		syncEvery, syncTimeout, logf)
 }
 
-// Another constructor that allows users to use Disk Size Limit feature
-// If user is not using Disk Size Limit feature, maxBytesDiskSize will
+// Another constructor that allows users to use Disk Space Limit feature
+// If user is not using Disk Space Limit feature, maxBytesDiskSpace will
 // be 0
-func NewWithDiskSize(name string, dataPath string,
-	maxBytesDiskSize int64, maxBytesPerFile int64,
+func NewWithDiskSpace(name string, dataPath string,
+	maxBytesDiskSpace int64, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
 	enableDiskLimitation := true
@@ -969,24 +965,6 @@ func (d *diskQueue) handleReadError() {
 		d.logf(ERROR,
 			"DISKQUEUE(%s) failed to rename bad diskqueue file %s to %s",
 			d.name, badFn, badRenameFn)
-	}
-
-	if d.enableDiskLimitation {
-		var badFileSize int64
-		if d.readFileNum == d.writeFileNum {
-			badFileSize = d.writeBytes
-		} else {
-			var stat os.FileInfo
-			stat, err = os.Stat(badRenameFn)
-			if err == nil {
-				badFileSize = stat.Size()
-			} else {
-				// max file size
-				badFileSize = int64(d.maxMsgSize) + d.maxBytesPerFile + 4 + numFileMsgsBytes
-			}
-		}
-
-		d.writeBytes -= badFileSize
 	}
 
 	d.readFileNum++

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -424,7 +424,7 @@ func (d *diskQueue) metaDataFileSize() int64 {
 	return metaDataFileSize
 }
 
-func (d *diskQueue) makeSpace() error {
+func (d *diskQueue) freeUpDiskSpace() error {
 	var err error
 
 	// check a .bad file exists if it does, delete that first
@@ -516,7 +516,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 
 	// check if we have enough space to write this message
 	for d.diskLimitFeatIsOn && d.writeBytes+d.metaDataFileSize() > d.maxBytesDiskSpace {
-		err = d.makeSpace()
+		err = d.freeUpDiskSpace()
 	}
 
 	// add all data to writeBuf before writing to file

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -649,11 +649,13 @@ func (d *diskQueue) moveForward() {
 	d.readFileNum = d.nextReadFileNum
 	d.readPos = d.nextReadPos
 	d.depth -= 1
-	d.readMessages += 1
+
+	if d.diskLimitFeatIsOn {
+		d.readMessages += 1
+	}
 
 	// see if we need to clean up the old file
 	if oldReadFileNum != d.nextReadFileNum {
-		d.readMessages = 0
 
 		// sync every time we start reading from a new file
 		d.needSync = true
@@ -664,7 +666,10 @@ func (d *diskQueue) moveForward() {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
 		}
 
-		d.writeBytes -= readFileLen
+		if d.diskLimitFeatIsOn {
+			d.readMessages = 0
+			d.writeBytes -= readFileLen
+		}
 	}
 
 	d.checkTailCorruption(d.depth)

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -174,8 +174,8 @@ func (d *diskQueue) start() {
 		d.logf(ERROR, "DISKQUEUE(%s) failed to retrieveMetaData - %s", d.name, err)
 	}
 
-	fileNameRegexp, _ = regexp.Compile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat$`)
-	badFileNameRegexp, _ = regexp.Compile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat.bad$`)
+	fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat$`)
+	badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat.bad$`)
 
 	d.updateTotalDiskSpaceUsed()
 

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -69,7 +69,6 @@ type diskQueue struct {
 	writeMessages int64
 	writeBytes    int64
 	depth         int64
-	badBytes      int64
 
 	sync.RWMutex
 
@@ -85,6 +84,7 @@ type diskQueue struct {
 	syncTimeout         time.Duration // duration of time per fsync
 	exitFlag            int32
 	needSync            bool
+	badBytes            int64
 
 	// keeps track of the position where we have read
 	// (but not yet sent over readChan)
@@ -426,8 +426,8 @@ func (d *diskQueue) metaDataFileSize() int64 {
 		}
 	}
 	if err != nil {
-		// use max file size (9 int64 fields)
-		metaDataFileSize = 72
+		// use max file size (8 int64 fields)
+		metaDataFileSize = 64
 	}
 
 	return metaDataFileSize

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -182,7 +182,6 @@ func (d *diskQueue) start() {
 	for _, badFileInfo := range badFileInfos {
 		d.badBytes += badFileInfo.Size()
 	}
-	d.logf(DEBUG, "BadBytes: %d", d.badBytes)
 
 	go d.ioLoop()
 }
@@ -500,18 +499,15 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 		pathArray := strings.Split(d.dataPath, "/")
 		mainDir = pathArray[len(pathArray)-1]
 	}
-	d.logf(DEBUG, "mainDir: %s", mainDir)
 
 	getBadFileInfos := func(pathStr string, dirEntry fs.DirEntry, err error) error {
 		if dirEntry.Name() == mainDir {
 			// we want to see the contents of this directory
-			d.logf(DEBUG, "We found main directory")
 			return nil
 		}
 
 		if dirEntry.IsDir() {
 			// if the entry is a directory, skip it
-			d.logf(DEBUG, "Skipping dir: %s", dirEntry.Name())
 			return fs.SkipDir
 		}
 
@@ -523,12 +519,11 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 
 		regExp, err := regexp.Compile(d.name + `.diskqueue.\d\d\d\d\d\d.dat.bad`)
 		if err == nil {
-			d.logf(DEBUG, "Compile successful")
 			matched = regExp.MatchString(dirEntry.Name())
 		} else {
 			matched, _ = regexp.Match(`.diskqueue.\d\d\d\d\d\d.dat.bad`, []byte(dirEntry.Name()))
 		}
-		d.logf(DEBUG, "%s, matched: %s. Name: %s", dirEntry.Name(), matched, d.name)
+
 		if matched {
 			badFileInfo, e := dirEntry.Info()
 			if e == nil && badFileInfo != nil {
@@ -543,8 +538,6 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 	if err != nil {
 		return nil
 	}
-
-	d.logf(DEBUG, "%s", badFileInfos)
 
 	return badFileInfos
 }

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -302,9 +302,12 @@ func (d *diskQueue) skipToNextRWFile() error {
 	d.nextReadFileNum = d.writeFileNum
 	d.nextReadPos = 0
 	d.depth = 0
-	d.readMessages = 0
-	d.writeMessages = 0
-	d.writeBytes = 0
+
+	if d.diskLimitFeatIsOn {
+		d.writeBytes = 0
+		d.readMessages = 0
+		d.writeMessages = 0
+	}
 
 	return err
 }

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -478,8 +478,6 @@ func (d *diskQueue) removeReadFile() error {
 		return err
 	}
 
-	d.logf(DEBUG, "messages in file: %d", totalMessages)
-
 	// update depth with the remaining number of messages
 	d.depth -= totalMessages - d.readMessages
 
@@ -934,7 +932,6 @@ func (d *diskQueue) handleReadError() {
 			// we moved on to the next writeFile
 			d.writeMessages = 0
 		}
-		d.logf(DEBUG, "estimated file size: %d", d.maxBytesPerFile)
 
 		// use lower estimate of file size
 		d.badBytes += d.maxBytesPerFile

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -601,6 +601,11 @@ func (d *diskQueue) writeOne(data []byte) error {
 	reachedFileSizeLimit := false
 
 	if d.diskLimitFeatIsOn {
+		// If there the data to be written is bigger than the disk size limit, do not write
+		if totalBytes+8 > d.maxBytesDiskSpace {
+			return errors.New("Not enough disk space to write message")
+		}
+
 		// check if we have enough space to write this message
 		metaDataFileSize := d.metaDataFileSize()
 

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -476,7 +476,7 @@ func (d *diskQueue) removeReadFile() error {
 	return nil
 }
 
-func (d *diskQueue) getOldestBadFileInfo() (fs.FileInfo, error) {
+func (d *diskQueue) getOldestBadFileInfo() fs.FileInfo {
 	var oldestBadFileInfo fs.FileInfo
 
 	getFirstBadFile := func(path string, d fs.DirEntry, err error) error {
@@ -503,20 +503,19 @@ func (d *diskQueue) getOldestBadFileInfo() (fs.FileInfo, error) {
 
 	err := filepath.WalkDir(d.dataPath, getFirstBadFile)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
-	return oldestBadFileInfo, nil
+	return oldestBadFileInfo
 }
 
 func (d *diskQueue) freeUpDiskSpace() error {
 	var err error
-	var oldestBadFileInfo fs.FileInfo
 
-	oldestBadFileInfo, err = d.getOldestBadFileInfo()
+	oldestBadFileInfo := d.getOldestBadFileInfo()
 
-	// check if a .bad file exists and no error occurred. if it does, delete that first
-	if err == nil && oldestBadFileInfo != nil {
+	// check if a .bad file exists. If it does, delete that first
+	if oldestBadFileInfo != nil {
 		badFileFilePath := path.Join(d.dataPath, oldestBadFileInfo.Name())
 
 		err = os.Remove(badFileFilePath)

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -533,7 +533,7 @@ func (d *diskQueue) freeDiskSpace(expectedBytesIncrease int64) error {
 			} else {
 				// recaclulate total bad files disk size to get most accurate info
 				d.totalDiskSpaceUsed -= oldestBadFileInfo.Size()
-				d.logf(INFO, "DISKQUEUE(%s) removed .bad file(%s) to free up disk space", d.name, oldestBadFileInfo.Name())
+				d.logf(INFO, "DISKQUEUE(%s) removed .bad file(%s) of size(%d bytes) to free up disk space", d.name, oldestBadFileInfo.Name(), oldestBadFileInfo.Size())
 			}
 
 			badFileInfos = badFileInfos[1:]
@@ -544,7 +544,6 @@ func (d *diskQueue) freeDiskSpace(expectedBytesIncrease int64) error {
 				d.logf(ERROR, "DISKQUEUE(%s) failed to remove file(%s) - %s", d.name, d.fileName(d.readFileNum), err)
 				d.handleReadError()
 				return err
-
 			} else {
 				d.logf(INFO, "DISKQUEUE(%s) removed file(%s) to free up disk space", d.name, d.fileName(d.readFileNum))
 			}
@@ -855,9 +854,14 @@ func (d *diskQueue) moveToNextReadFile() {
 		d.needSync = true
 
 		fn := d.fileName(oldReadFileNum)
+		oldFileInfo, _ := os.Stat(fn)
+		oldFileSize := oldFileInfo.Size()
+
 		err := os.Remove(fn)
 		if err != nil {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
+		} else {
+			d.logf(INFO, "DISKQUEUE(%s) removed(%s) of size(%d bytes)", d.name, fn, oldFileSize)
 		}
 
 		if d.enableDiskLimitation {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -521,7 +521,7 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 		if err == nil {
 			matched = regExp.MatchString(dirEntry.Name())
 		} else {
-			matched, _ = regexp.Match(`.diskqueue.\d\d\d\d\d\d.dat.bad`, []byte(dirEntry.Name()))
+			matched, _ = regexp.MatchString(`.diskqueue.\d\d\d\d\d\d.dat.bad`, dirEntry.Name())
 		}
 
 		if matched {

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -182,6 +182,7 @@ func (d *diskQueue) start() {
 	for _, badFileInfo := range badFileInfos {
 		d.badBytes += badFileInfo.Size()
 	}
+	d.logf(DEBUG, "BadBytes: %d", d.badBytes)
 
 	go d.ioLoop()
 }
@@ -499,15 +500,18 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 		pathArray := strings.Split(d.dataPath, "/")
 		mainDir = pathArray[len(pathArray)-1]
 	}
+	d.logf(DEBUG, "mainDir: %s", mainDir)
 
-	getBadFileInfos := func(path string, d fs.DirEntry, err error) error {
-		if d.Name() == mainDir {
+	getBadFileInfos := func(pathStr string, dirEntry fs.DirEntry, err error) error {
+		if dirEntry.Name() == mainDir {
 			// we want to see the contents of this directory
+			d.logf(DEBUG, "We found main directory")
 			return nil
 		}
 
-		if d.IsDir() {
+		if dirEntry.IsDir() {
 			// if the entry is a directory, skip it
+			d.logf(DEBUG, "Skipping dir: %s", dirEntry.Name())
 			return fs.SkipDir
 		}
 
@@ -515,9 +519,18 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 			return err
 		}
 
-		matched, _ := regexp.Match(`test_dq.diskqueue.\d\d\d\d\d\d.dat.bad`, []byte(d.Name()))
+		var matched bool
+
+		regExp, err := regexp.Compile(d.name + `.diskqueue.\d\d\d\d\d\d.dat.bad`)
+		if err == nil {
+			d.logf(DEBUG, "Compile successful")
+			matched = regExp.MatchString(dirEntry.Name())
+		} else {
+			matched, _ = regexp.Match(`.diskqueue.\d\d\d\d\d\d.dat.bad`, []byte(dirEntry.Name()))
+		}
+		d.logf(DEBUG, "%s, matched: %s. Name: %s", dirEntry.Name(), matched, d.name)
 		if matched {
-			badFileInfo, e := d.Info()
+			badFileInfo, e := dirEntry.Info()
 			if e == nil && badFileInfo != nil {
 				badFileInfos = append(badFileInfos, badFileInfo)
 			}
@@ -530,6 +543,8 @@ func (d *diskQueue) getAllBadFileInfo() []fs.FileInfo {
 	if err != nil {
 		return nil
 	}
+
+	d.logf(DEBUG, "%s", badFileInfos)
 
 	return badFileInfos
 }

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -838,7 +838,7 @@ corruptFiles:
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	panic("fail3")
+	panic("fail")
 
 readCorruptedFile:
 	// test handleReadError
@@ -846,7 +846,7 @@ readCorruptedFile:
 	// there should be no "bad" files at this point
 	badFilesCount = numberOfBadFiles(dqName, tmpDir)
 	if badFilesCount != 0 {
-		panic("fail1-")
+		panic("fail")
 	}
 
 	// corrupt file 2
@@ -864,7 +864,7 @@ readCorruptedFile:
 	// check if the file was converted into a .bad file
 	badFilesCount = numberOfBadFiles(dqName, tmpDir)
 	if badFilesCount != 1 {
-		panic("fail2-")
+		panic("fail")
 	}
 
 	// go over the disk limit
@@ -878,7 +878,7 @@ readCorruptedFile:
 	badFilesCount = numberOfBadFiles(dqName, tmpDir)
 	if badFilesCount != 0 {
 		t.Log("BAD FILE COUNT:", badFilesCount)
-		panic("fail3-")
+		panic("fail")
 	}
 
 	for i := 0; i < 10; i++ {

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -499,7 +499,6 @@ completeWriteFileAgain:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 7 &&
-			d.writeBytes == 5068 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 3 &&
 			d.readMessages == 0 &&
@@ -533,7 +532,6 @@ completeReadFileAgain:
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 0 &&
-			d.writeBytes == 0 &&
 			d.readFileNum == 3 &&
 			d.writeFileNum == 3 &&
 			d.readMessages == 0 &&

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -350,7 +350,7 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewWithDiskSpace(dqName, tmpDir, 1<<11, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	dq := NewWithDiskSpace(dqName, tmpDir, 6000, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
 	defer dq.Close()
 
 	msgSize := 1000

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -395,6 +395,10 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 	msg := make([]byte, msgSize)
 	dq.Put(msg)
 
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
+
 	metaDataSize := metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
@@ -416,6 +420,10 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 next:
 	dq.Put(msg)
 	<-dq.ReadChan()
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
 
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
@@ -444,6 +452,10 @@ completeWriteFile:
 	dq.Put(make([]byte, bytesRemaining-4-oneByteMsgSizeIncrease))
 	dq.Put(make([]byte, 1))
 
+	if dq.Depth() != 3 {
+		panic("fail")
+	}
+
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
 		// test that write position and messages reset when a new file is created
@@ -471,6 +483,10 @@ completeReadFile:
 	<-dq.ReadChan()
 	<-dq.ReadChan()
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
 
 	for i := 0; i < 10; i++ {
 		// test that read position and messages reset when a file is completely read
@@ -503,6 +519,10 @@ completeWriteFileAgain:
 	dq.Put(make([]byte, bytesRemaining-4-oneByteMsgSizeIncrease))
 	dq.Put(make([]byte, 1))
 
+	if dq.Depth() != 7 {
+		panic("fail")
+	}
+
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
 		// test that write position and messages reset when a file is completely read
@@ -532,6 +552,10 @@ completeReadFileAgain:
 	<-dq.ReadChan()
 	<-dq.ReadChan()
 	<-dq.ReadChan()
+
+	if dq.Depth() != 0 {
+		panic("fail")
+	}
 
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
@@ -570,6 +594,10 @@ meetDiskSizeLimit:
 	diskBytesRemaining := 6040 - metaDataFileSize(dq.(*diskQueue).metaDataFileName()) - (totalDiskBytes + 12)
 	dq.Put(make([]byte, diskBytesRemaining))
 
+	if dq.Depth() != 6 {
+		panic("fail")
+	}
+
 	for i := 0; i < 10; i++ {
 		// test that read position and messages reset when a file is completely read
 		// test the readFileNum correctly increments
@@ -591,6 +619,10 @@ meetDiskSizeLimit:
 
 surpassDiskSizeLimit:
 	dq.Put(make([]byte, 1))
+
+	if dq.Depth() != 4 {
+		panic("fail")
+	}
 
 	for i := 0; i < 10; i++ {
 		// test that read position and messages reset when a file is completely read
@@ -641,6 +673,10 @@ func TestDiskSizeImplementationMsgSizeGreaterThanFileSize(t *testing.T) {
 	// file size: 1512
 	dq.Put(make([]byte, 1500))
 
+	if dq.Depth() != 5 {
+		panic("fail")
+	}
+
 	metaDataSize := metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
@@ -662,6 +698,10 @@ func TestDiskSizeImplementationMsgSizeGreaterThanFileSize(t *testing.T) {
 writeLargeMsg:
 	// Write a large message that causes the deletion of three files
 	dq.Put(make([]byte, 3000))
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
 
 	metaDataSize = metaDataFileSize(dq.(*diskQueue).metaDataFileName())
 	for i := 0; i < 10; i++ {
@@ -803,6 +843,10 @@ func TestDiskSizeImplementationWithBadFiles(t *testing.T) {
 	// check if all the .bad files were deleted
 	badFilesCount = numberOfBadFiles(dqName, tmpDir)
 	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	if dq.Depth() != 5 {
 		panic("fail")
 	}
 

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -363,10 +363,10 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 			d.writeBytes == 1004 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
-			d.readPos == 0 &&
-			d.writePos == 1004 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 1 {
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 {
 			// success
 			goto next
 		}
@@ -384,10 +384,10 @@ next:
 			d.writeBytes == 2008 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
-			d.readPos == 1004 &&
-			d.writePos == 2008 &&
 			d.readMessages == 1 &&
-			d.writeMessages == 2 {
+			d.writeMessages == 2 &&
+			d.readPos == 1004 &&
+			d.writePos == 2008 {
 			// success
 			goto completeWriteFile
 		}
@@ -409,13 +409,13 @@ completeWriteFile:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 3 &&
-			d.writeBytes == 3020 &&
+			d.writeBytes == 2048 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 1 &&
-			d.readPos == 1004 &&
-			d.writePos == 0 &&
 			d.readMessages == 1 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 1004 &&
+			d.writePos == 0 {
 			// success
 			goto completeReadFile
 		}
@@ -439,10 +439,10 @@ completeReadFile:
 			d.writeBytes == 1004 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 1 &&
-			d.readPos == 0 &&
-			d.writePos == 1004 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 1 {
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 {
 			// success
 			goto completeWriteFileAgain
 		}
@@ -467,12 +467,13 @@ completeWriteFileAgain:
 		// test the writeFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 7 &&
+			d.writeBytes == 5068 &&
 			d.readFileNum == 1 &&
 			d.writeFileNum == 3 &&
-			d.readPos == 0 &&
-			d.writePos == 0 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 {
 			// success
 			goto completeReadFileAgain
 		}
@@ -495,12 +496,13 @@ completeReadFileAgain:
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 0 &&
+			d.writeBytes == 0 &&
 			d.readFileNum == 3 &&
 			d.writeFileNum == 3 &&
-			d.readPos == 0 &&
-			d.writePos == 0 &&
 			d.readMessages == 0 &&
-			d.writeMessages == 0 {
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 {
 			// success
 			goto done
 		}

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -263,7 +263,7 @@ type md struct {
 	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
+func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -271,7 +271,7 @@ func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried, diskLimitFeatIsOn)
+			return readMetaDataFile(fileName, retried, enableDiskLimitation)
 		}
 		panic(err)
 	}
@@ -279,7 +279,7 @@ func readMetaDataFile(fileName string, retried int, diskLimitFeatIsOn bool) md {
 
 	var ret md
 
-	if diskLimitFeatIsOn {
+	if enableDiskLimitation {
 		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d,%d\n",
 			&ret.depth,
 			&ret.readFileNum, &ret.readMessages, &ret.readPos,

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -350,7 +350,7 @@ func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	dq := NewWithDiskSpace(dqName, tmpDir, 7000, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	dq := NewWithDiskSpace(dqName, tmpDir, 6040, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
 	defer dq.Close()
 
 	msgSize := 1000
@@ -434,7 +434,6 @@ completeReadFile:
 		// test that read position and messages reset when a file is completely read
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
-		t.Logf("Write bytes: %d", d.writeBytes)
 		if d.depth == 1 &&
 			d.writeBytes == 1004 &&
 			d.readFileNum == 1 &&
@@ -516,18 +515,34 @@ meetDiskSizeLimit:
 	dq.Put(msg)
 	dq.Put(msg)
 
-	// meet the file size limit exactly (2048 bytes) when writeFileNum
+	// meet the disk size limit exactly (6040 bytes) when writeFileNum
 	// is ahead of readFileNum
 	dq.Put(msg)
 	dq.Put(msg)
-	dq.Put(msg)
+
+	totalDiskBytes := int64(5*(msgSize+4) + 8)
+
+	metaDataFile, err := os.OpenFile(dq.(*diskQueue).metaDataFileName(), os.O_RDONLY, 0600)
+
+	var metaDataFileSize int64
+	if err == nil {
+		var stat os.FileInfo
+
+		stat, err = metaDataFile.Stat()
+		if err == nil {
+			metaDataFileSize = stat.Size()
+		}
+	}
+
+	diskBytesRemaining := 6040 - metaDataFileSize - (totalDiskBytes + 12)
+	dq.Put(make([]byte, diskBytesRemaining))
 
 	for i := 0; i < 10; i++ {
 		// test that read position and messages reset when a file is completely read
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 6 &&
-			d.writeBytes == 6040 &&
+			d.writeBytes == 6040-metaDataFileSize &&
 			d.readFileNum == 3 &&
 			d.writeFileNum == 5 &&
 			d.readMessages == 0 &&
@@ -542,22 +557,20 @@ meetDiskSizeLimit:
 	panic("fail")
 
 surpassDiskSizeLimit:
-	t.Log("Start")
-	dq.Put(msg)
-	t.Log("Msg put")
+	dq.Put(make([]byte, 1))
 
 	for i := 0; i < 10; i++ {
 		// test that read position and messages reset when a file is completely read
 		// test the readFileNum correctly increments
 		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
 		if d.depth == 4 &&
-			d.writeBytes == 4024 &&
+			d.writeBytes == 3025-metaDataFileSize &&
 			d.readFileNum == 4 &&
 			d.writeFileNum == 5 &&
 			d.readMessages == 0 &&
 			d.writeMessages == 1 &&
 			d.readPos == 0 &&
-			d.writePos == 1004 {
+			d.writePos == 5 {
 			// success
 			goto done
 		}

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -382,7 +382,7 @@ func metaDataFileSize(metaDataFileName string) int64 {
 
 func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
 	l := NewTestLogger(t)
-	dqName := "test_disk_queue_read_after_sync" + strconv.Itoa(int(time.Now().Unix()))
+	dqName := "test_disk_queue_read_with_disk_size_implementation" + strconv.Itoa(int(time.Now().Unix()))
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
 	if err != nil {
 		panic(err)
@@ -650,7 +650,7 @@ func TestDiskSizeImplementationMsgSizeGreaterThanFileSize(t *testing.T) {
 	// write three files
 
 	l := NewTestLogger(t)
-	dqName := "test_disk_queue_read_after_sync" + strconv.Itoa(int(time.Now().Unix()))
+	dqName := "test_disk_queue_implementation_msg_size_greater_than_file_size" + strconv.Itoa(int(time.Now().Unix()))
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
 	if err != nil {
 		panic(err)
@@ -788,7 +788,7 @@ func TestDiskSizeImplementationWithBadFiles(t *testing.T) {
 	// write three files
 
 	l := NewTestLogger(t)
-	dqName := "test_disk_queue_read_after_sync" + strconv.Itoa(int(time.Now().Unix()))
+	dqName := "test_disk_queue_implementation_with_bad_files" + strconv.Itoa(int(time.Now().Unix()))
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/nsqio/go-diskqueue
+module github.com/kev1n80/go-diskqueue
 
 go 1.13


### PR DESCRIPTION
# Implementation
- Get metaData file size
- Get accurate count of writeBytes whenever a readFile is deleted or a readFile is converted into a .bad file
- Get all bad file info
- Remove read file
- Check to see if there is enough space when writing data to file
  - If there is not, delete all .bad files before deleting readFile
- Abstract code from moveForward() to create moveToNextReadFile() which is also used in removeReadFile()

# Testing
- Test that files are deleted when a new write to file will surpass disk size limit
- Test that if data size is greater than file size and the new write to file will surpass disk size limit, DiskQueue will delete multiple files
- Test that DiskQueue will delete .bad files before deleting readFile
- Test that DiskQueue is able to account for preexisting .bad files associated with DiskQueue object 
- Test that DiskQueue is able to remove corrupted files when making disk space
- Test that DiskQueue is able to account for corrupted files when reading one and converting the corrupted read file into a bad file
# Note 
Half of the PR is code for testing