### PR TITLE
Read correct number of messages from end of file

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -463,8 +463,6 @@ func (d *diskQueue) readNumOfMessages(fileName string) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-
-		d.reader = bufio.NewReader(d.readFile)
 	}
 
 	closeReadFile := func() {
@@ -480,7 +478,7 @@ func (d *diskQueue) readNumOfMessages(fileName string) (int64, error) {
 	}
 
 	var totalMessages int64
-	err = binary.Read(d.reader, binary.BigEndian, &totalMessages)
+	err = binary.Read(d.readFile, binary.BigEndian, &totalMessages)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Directly read from file instead of the `bufio.Reader` to prevent wrong data from buffer.

Also with some trivial improvements on checkes:
  - deleted the `if expectedBytesIncrease > d.maxBytesDiskSpace` check from `freeDiskSpace` because the same check has been done already in `checkDiskSpace`.
  - in constructor, ensure disk size limit is larger than a max sized file + metadata file.