### PR TITLE
Update \d\d\d\d\d\d to \d+

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -186,8 +186,8 @@ func (d *diskQueue) start() error {
 		d.logf(ERROR, "DISKQUEUE(%s) failed to retrieveMetaData - %s", d.name, err)
 	}
 
-	fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat$`)
-	badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d\d\d\d\d\d.dat.bad$`)
+	fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat$`)
+	badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat.bad$`)
 
 	d.updateTotalDiskSpaceUsed()
 


### PR DESCRIPTION
When filenum >= 1000000, fileNameRegexp couldn't match that filename.

```
fmt.Println(fmt.Sprintf( "%s.diskqueue.%06d.dat", "abc", 100000000)) = abc.diskqueue.100000000.dat
```
