### PR TITLE
bugfix: Fixed issue with global shared RegExps for queue

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -30,8 +30,6 @@ const (
 	maxMetaDataFileSize = 56
 )
 
-var badFileNameRegexp, fileNameRegexp *regexp.Regexp
-
 type AppLogFunc func(lvl LogLevel, f string, args ...interface{})
 
 func (l LogLevel) String() string {
@@ -115,6 +113,8 @@ type diskQueue struct {
 
 	// disk limit implementation flag
 	enableDiskLimitation bool
+
+	badFileNameRegexp, fileNameRegexp *regexp.Regexp
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata
@@ -186,8 +186,8 @@ func (d *diskQueue) start() error {
 		d.logf(ERROR, "DISKQUEUE(%s) failed to retrieveMetaData - %s", d.name, err)
 	}
 
-	fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat$`)
-	badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat.bad$`)
+	d.fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat$`)
+	d.badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat.bad$`)
 
 	d.updateTotalDiskSpaceUsed()
 
@@ -538,7 +538,7 @@ func (d *diskQueue) getAllBadFileInfo() ([]os.FileInfo, error) {
 
 	getAllBadFileInfo := func(fileInfo os.FileInfo) error {
 		// only accept "bad" files created by this DiskQueue object
-		if badFileNameRegexp.MatchString(fileInfo.Name()) {
+		if d.badFileNameRegexp.MatchString(fileInfo.Name()) {
 			badFileInfos = append(badFileInfos, fileInfo)
 		}
 
@@ -556,7 +556,7 @@ func (d *diskQueue) updateTotalDiskSpaceUsed() {
 
 	updateTotalDiskSpaceUsed := func(fileInfo os.FileInfo) error {
 		// only accept files created by this DiskQueue object
-		if fileNameRegexp.MatchString(fileInfo.Name()) || badFileNameRegexp.MatchString(fileInfo.Name()) {
+		if d.fileNameRegexp.MatchString(fileInfo.Name()) || d.badFileNameRegexp.MatchString(fileInfo.Name()) {
 			d.totalDiskSpaceUsed += fileInfo.Size()
 		}
 


### PR DESCRIPTION
When multiple instances of queue instantiated shared regexp can result in incorrect regexp used for all except last instance of queue created.